### PR TITLE
Fix crash in Wave Defense scenario game

### DIFF
--- a/auto-resource-redux/control.lua
+++ b/auto-resource-redux/control.lua
@@ -49,11 +49,17 @@ local function on_tick()
 end
 
 local function on_built(event)
+  if not initialised then
+    return
+  end
   EntityManager.on_entity_created(event)
   EntityCustomData.on_built(event)
 end
 
 local function on_cloned(event)
+  if not initialised then
+    return
+  end
   EntityManager.on_entity_created(event)
   EntityCustomData.on_cloned(event)
 end

--- a/auto-resource-redux/src/EntityManager.lua
+++ b/auto-resource-redux/src/EntityManager.lua
@@ -175,7 +175,7 @@ function EntityManager.on_entity_created(event)
   if entity == nil then
     entity = event.entity
   end
-  if global.forces == nil or global.forces[entity.force.name] == nil then
+  if global.forces[entity.force.name] == nil then
     return
   end
   local queue_key = manage_entity(entity, true)

--- a/auto-resource-redux/src/EntityManager.lua
+++ b/auto-resource-redux/src/EntityManager.lua
@@ -175,7 +175,7 @@ function EntityManager.on_entity_created(event)
   if entity == nil then
     entity = event.entity
   end
-  if global.forces[entity.force.name] == nil then
+  if global.forces == nil or global.forces[entity.force.name] == nil then
     return
   end
   local queue_key = manage_entity(entity, true)


### PR DESCRIPTION
Starting a game of Wave defense with this mod causes a crash because the entity created event is sent before `global.forces` is set.
Check for nil. An entity scan happens later, so nothing is lost.